### PR TITLE
CAD-704: Create Box Zoom Functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-map-react-mark43",
-  "version": "0.21.11",
+  "version": "0.22.0",
   "description": "isomorphic google map react component, allows render react components on the google map",
   "main": "lib/index",
   "scripts": {

--- a/src/google_map.js
+++ b/src/google_map.js
@@ -164,7 +164,7 @@ export default class GoogleMap extends Component {
     this.geoJsonRendered = false;
 
     this.zoomBoxMode = false;
-    this.mapMode = "DARK_MODE";
+    this.mapMode = 'DARK_MODE';
     this.polylines = [];
     this.polygons = [];
     this.circles = [];
@@ -242,7 +242,6 @@ export default class GoogleMap extends Component {
       detectElementResize.addResizeListener(mapDom, that._mapDomResizeCallback);
     }
   }
-
 
   componentWillReceiveProps(nextProps) {
     if (process.env.NODE_ENV !== 'production') {
@@ -384,13 +383,13 @@ export default class GoogleMap extends Component {
       if (nextProps.zoomBoxMode) {
         // Update style based on the map mode only on change
         if (this.props.mapMode !== nextProps.mapMode) {
-          if (nextProps.mapMode === "DARK_MODE") {
+          if (nextProps.mapMode === 'DARK_MODE') {
             this.drawingManager_.setOptions({
               rectangleOptions: {
                 strokeColor: '#00C2FF',
                 strokeWeight: 1,
                 fillColor: '#00C2FF',
-                fillOpacity: 0.1,
+                fillOpacity: 0.1
               }
             });
           } else {
@@ -399,7 +398,7 @@ export default class GoogleMap extends Component {
                 strokeColor: '#FFFFFF',
                 strokeWeight: 1,
                 fillColor: '#FFFFFF',
-                fillOpacity: 0.1,
+                fillOpacity: 0.1
               }
             });
           }
@@ -414,7 +413,7 @@ export default class GoogleMap extends Component {
       } else if (this.state.drawingManagerCreated) {
         // turn off drawing if zoomBoxMode is false and you were currently drawing
         this.drawingManager_.setOptions({
-          drawingMode : null
+          drawingMode: null
         });
         this.setState({ drawingManagerCreated: false });
       }
@@ -650,7 +649,6 @@ export default class GoogleMap extends Component {
       mapOptions.minZoom = this._checkMinZoom(mapOptions.minZoom, minZoom);
 
       const map = new maps.Map(ReactDOM.findDOMNode(this.refs.google_map_dom), mapOptions);
-      // console.log('map init OMGO OMG OM G');
 
       this.map_ = map;
       this.maps_ = maps;
@@ -659,7 +657,7 @@ export default class GoogleMap extends Component {
       this.drawingManager_.setOptions({
         drawingMode: null,
         drawingControl: false, // hides control bar
-        rectangleOptions : {
+        rectangleOptions: {
           strokeColor: '#00C2FF',
           strokeWeight: 1,
           fillColor: '#00C2FF',
@@ -770,13 +768,13 @@ export default class GoogleMap extends Component {
       }
 
       // listen for rectangle to be drawn
-      maps.event.addListener(this.drawingManager_, 'rectanglecomplete', function(event) {
+      maps.event.addListener(this.drawingManager_, 'rectanglecomplete', event => {
         // turn of draw
         this_.drawingManager_.setOptions({
           drawingMode: null,
         });
         this_.setState({ drawingManagerCreated: false });
-        
+
         const mapBounds = map.getBounds();
         const mapHeight = mapBounds.getNorthEast().lat() - mapBounds.getSouthWest().lat();
         const mapWidth = mapBounds.getNorthEast().lng() - mapBounds.getSouthWest().lng();
@@ -786,9 +784,9 @@ export default class GoogleMap extends Component {
         const rectWidth = rectBounds.getNorthEast().lng() - rectBounds.getSouthWest().lng();
 
         // calc how much to zoom
-        const widthZoom = mapWidth/rectWidth;
-        const heightZoom = mapHeight/rectHeight;
-      
+        const widthZoom = mapWidth / rectWidth;
+        const heightZoom = mapHeight / rectHeight;
+
         // apply new zoomLevel and center map
         let newZoom;
         if (heightZoom < widthZoom) {
@@ -800,7 +798,7 @@ export default class GoogleMap extends Component {
           map.setZoom(map.getZoom() + newZoom);
         }
         map.setCenter(event.getBounds().getCenter());
-        
+
         // remove rectangle
         event.setMap(null);
       });

--- a/src/utils/loaders/google_map_loader.js
+++ b/src/utils/loaders/google_map_loader.js
@@ -59,7 +59,7 @@ export default function googleMapLoader(bootstrapURLKeys) {
       );
 
     $script_(
-      `https://maps.googleapis.com/maps/api/js?callback=_$_google_map_initialize_$_${queryString}`,
+      `https://maps.googleapis.com/maps/api/js?callback=_$_google_map_initialize_$_${queryString}&libraries=drawing`,
       () =>
         typeof window.google === 'undefined' &&
           reject(new Error('google map initialization error (not loaded)'))


### PR DESCRIPTION
## Release Notes and Issues
This creates the functionality for box zoom by using Google Maps drawing manager. It allows us to draw a rectangle, calculate the zoom, and propagate the change.

[CAD-704](https://mark43.atlassian.net/browse/CAD-704)

**New Feature Testing Notes for QA:**
- Select the magnifying glass button in the top right corner. When activated that button will change colors and the cursor on the map will be a cross.
- Once activated click, drag, and release or click, move mouse, and click again to draw a rectangle. The map will zoom to the rectangle as much as possible without cutting out anything enclosed by the drawn rectangle. You will also deactivate the box zoom mode.
- Once activated you can switch map modes and stay in box zoom. The color of the drawn rectangle should change.
- While activated if you select a category, manipulate the zoom/map with a scroll or the other zoom controls, or click the box zoom button again you will deactivate box zoom mode.

### General notes
- [x] My PR's name starts with a CAD ticket number (if there is one)
- [x] My changes have corresponding tests that run in CI

### Front end
- [x] I removed console references, window references, and general shenanigans